### PR TITLE
Refactor/creature list container

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "babel-polyfill": "^6.23.0",
+    "lodash": "^4.17.4",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -109,10 +109,8 @@ Counter.propTypes = {
   counterId: PropTypes.string.isRequired,
 }
 
-const mapStateToProps = (state, ownProps) => {
-  return {
-    counter: state.counters.byId[ownProps.counterId],
-  };
+const mapStateToProps = (state) => {
+  return {};
 };
 
 const mapDispatchToProps = dispatch => {

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,7 +1,7 @@
 // Libs
 import React from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 
 // Actions
@@ -105,18 +105,10 @@ class Counter extends React.Component {
   }
 }
 
-Counter.propTypes = {
-  counterId: PropTypes.string.isRequired,
-}
-
-const mapStateToProps = (state) => {
-  return {};
-};
-
 const mapDispatchToProps = dispatch => {
   return {
     _counter: bindActionCreators(counterActions, dispatch)
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Counter);
+export default connect(null, mapDispatchToProps)(Counter);

--- a/src/components/Creature.js
+++ b/src/components/Creature.js
@@ -1,20 +1,27 @@
 // Libs
 import React from 'react';
 // import PropTypes from 'prop-types';
+import _ from 'lodash';
 
 // Child Components
-import Counter from './Counter'
-import {CreateButton} from './CreateButton'
+import Counter from './Counter';
+import {CreateButton} from './CreateButton';
 
-export const Creature = (props) => {
-    const {creature} = props
+export class Creature extends React.Component {
+
+  handleCounterSubmit = label => {
+    this.props.onCounterSubmit({label, creatureId: this.props.creature.id})
+  };
+
+  render() {
+    const {creature} = this.props
     var counters = []
-    if(creature.counterIds.length > 0) {
-      creature.counterIds.forEach((counterId) => {
+    if(_.size(this.props.counters) > 0) {
+      this.props.counters.forEach((counter) => {
         counters.push(
           <Counter
-            key={counterId}
-            counterId={counterId}
+            key={counter.id}
+            counter={counter}
           />
         );
       });
@@ -24,7 +31,8 @@ export const Creature = (props) => {
       <div className="creature">
         <h2 className="creature_name">{creature.name}</h2>
         {counters}
-        <CreateButton onSubmit={props.onCounterSubmit} buttonLabel="New Counter" />
+        <CreateButton onSubmit={this.handleCounterSubmit} buttonLabel="New Counter" />
       </div>
     );
   }
+}

--- a/src/components/Creature.js
+++ b/src/components/Creature.js
@@ -17,7 +17,7 @@ export class Creature extends React.Component {
     const {creature} = this.props
     var counters = []
     if(_.size(this.props.counters) > 0) {
-      this.props.counters.forEach((counter) => {
+      _.forEach(this.props.counters, (counter) => {
         counters.push(
           <Counter
             key={counter.id}

--- a/src/components/Creature.js
+++ b/src/components/Creature.js
@@ -1,26 +1,16 @@
 // Libs
 import React from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
+// import PropTypes from 'prop-types';
 
 // Child Components
 import Counter from './Counter'
 import {CreateButton} from './CreateButton'
 
-// Actions
-import * as counterActions from '../actions/counters';
-
-class Creature extends React.Component {
-  onCounterSubmit = label => {
-    this.props._counter.counterCreate({label, creatureId: this.props.creature.id})
-  }
-
-  render() {
-    const {counterIds} = this.props
+export const Creature = (props) => {
+    const {creature} = props
     var counters = []
-    if(counterIds.length > 0) {
-      counterIds.forEach((counterId) => {
+    if(creature.counterIds.length > 0) {
+      creature.counterIds.forEach((counterId) => {
         counters.push(
           <Counter
             key={counterId}
@@ -32,35 +22,9 @@ class Creature extends React.Component {
 
     return(
       <div className="creature">
-        <h2 className="creature_name">{this.props.creature.name}</h2>
+        <h2 className="creature_name">{creature.name}</h2>
         {counters}
-        <CreateButton onSubmit={this.onCounterSubmit} buttonLabel="New Counter" />
+        <CreateButton onSubmit={props.onCounterSubmit} buttonLabel="New Counter" />
       </div>
     );
   }
-}
-
-Creature.propTypes = {
-  creatureId: PropTypes.string.isRequired,
-  creature: PropTypes.object,
-  counterIds: PropTypes.array,
-}
-
-Creature.defaultProps = {
-  counterIds: [],
-}
-
-const mapStateToProps = (state, ownProps) => {
-  return {
-    creature: state.creatures.byId[ownProps.creatureId],
-    counterIds: state.creatures.byId[ownProps.creatureId].counterIds,
-  };
-};
-
-const mapDispatchToProps = dispatch => {
-  return {
-    _counter: bindActionCreators(counterActions, dispatch)
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(Creature);

--- a/src/components/CreatureList.js
+++ b/src/components/CreatureList.js
@@ -4,13 +4,16 @@ import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc'
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
+import _ from 'lodash';
 
 // Child Components
-import Creature from './Creature'
+import {Creature} from './Creature'
 import {CreateButton} from './CreateButton'
 
 // Actions
 import * as creatureActions from '../actions/creatures';
+import * as counterActions from '../actions/counters';
+
 
 const SortableItem = SortableElement(({value}) =>
   <div className="SortableItem">{value}</div>
@@ -56,15 +59,23 @@ class CreatureList extends React.Component {
     });
   };
 
+  // From Creature
+  handleCounterSubmit = label => {
+    this.props._counter.counterCreate({label, creatureId: this.props.creature.id})
+  };
+
+//  From Counter
+
+
   render() {
-    const {creatureIds} = this.state;
     var creatures = []
-    if(creatureIds.length > 0) {
-      creatureIds.forEach((creatureId) => {
+    if(_.size(this.props.creatures) > 0) {
+      _.forEach(this.props.creatures, (creature) => {
         creatures.push(
           <Creature
-            key={creatureId}
-            creatureId={creatureId}
+            key={creature.id}
+            creature={creature}
+            onCounterSubmit={this.handleCounterSubmit}
           />
         );
       });
@@ -102,13 +113,15 @@ CreatureList.defaultProps = {
 
 const mapStateToProps = (state) => {
   return {
-    creatureIds: state.creatures.allIds,
+    creatures: state.creatures.byId,
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    _creature: bindActionCreators(creatureActions, dispatch)
+    _creature: bindActionCreators(creatureActions, dispatch),
+    _counter: bindActionCreators(counterActions, dispatch)
+
   };
 };
 

--- a/src/components/CreatureList.js
+++ b/src/components/CreatureList.js
@@ -71,9 +71,7 @@ class CreatureList extends React.Component {
     var creatures = []
     if(_.size(this.props.creatures) > 0) {
       _.forEach(this.props.creatures, (creature) => {
-        const counters = _.filter((this.props.counters), (counter) => {
-          _.includes(creature.counterIds, counter.id)
-        })
+        const counters = _.pick(this.props.counters, creature.counterIds)
         creatures.push(
           <Creature
             key={creature.id}

--- a/src/components/CreatureList.js
+++ b/src/components/CreatureList.js
@@ -59,13 +59,9 @@ class CreatureList extends React.Component {
     });
   };
 
-  // From Creature
   handleCounterSubmit = counter => {
     this.props._counter.counterCreate(counter)
   };
-
-//  From Counter
-
 
   render() {
     var creatures = []

--- a/src/components/CreatureList.js
+++ b/src/components/CreatureList.js
@@ -60,8 +60,8 @@ class CreatureList extends React.Component {
   };
 
   // From Creature
-  handleCounterSubmit = label => {
-    this.props._counter.counterCreate({label, creatureId: this.props.creature.id})
+  handleCounterSubmit = counter => {
+    this.props._counter.counterCreate(counter)
   };
 
 //  From Counter
@@ -71,10 +71,14 @@ class CreatureList extends React.Component {
     var creatures = []
     if(_.size(this.props.creatures) > 0) {
       _.forEach(this.props.creatures, (creature) => {
+        const counters = _.filter((this.props.counters), (counter) => {
+          _.includes(creature.counterIds, counter.id)
+        })
         creatures.push(
           <Creature
             key={creature.id}
             creature={creature}
+            counters={counters}
             onCounterSubmit={this.handleCounterSubmit}
           />
         );
@@ -114,6 +118,7 @@ CreatureList.defaultProps = {
 const mapStateToProps = (state) => {
   return {
     creatures: state.creatures.byId,
+    counters: state.counters.byId
   };
 };
 
@@ -121,7 +126,6 @@ const mapDispatchToProps = (dispatch) => {
   return {
     _creature: bindActionCreators(creatureActions, dispatch),
     _counter: bindActionCreators(counterActions, dispatch)
-
   };
 };
 


### PR DESCRIPTION
This will make the Creature and Counter components true components that receive their state via props from their parent container, CreatureList. The Counter component will remain connected to the store in order to dispatch its own `counterUpdate` action. This makes sense at this time because we want the Counter component to be as reusable as possible. This way it only requires that each counter be instantiated from a parent container, but all count changes are maintained in the Counter's local state and the ability to update the store is locally available as well.

Notes:
-Look to make Creature a functional component rather than a class component.
-Still need proper type-checking with PropTypes