### PR TITLE
feature/creature-delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5495,14 +5495,6 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
       "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
     },
-    "lodash-move": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/lodash-move/-/lodash-move-1.1.1.tgz",
-      "integrity": "sha1-WfduDxrFfm2Gg/UxvsB8W26k40g=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,11 @@
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
+    "array-move": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-1.0.0.tgz",
+      "integrity": "sha1-7F3kcsqwuds+UJY/1xR2ukd6ZYM="
+    },
     "array-reduce": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
@@ -5489,6 +5494,14 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
       "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+    },
+    "lodash-move": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/lodash-move/-/lodash-move-1.1.1.tgz",
+      "integrity": "sha1-WfduDxrFfm2Gg/UxvsB8W26k40g=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "array-move": "^1.0.0",
     "babel-polyfill": "^6.23.0",
     "lodash": "^4.17.4",
+    "lodash-move": "^1.1.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "array-move": "^1.0.0",
     "babel-polyfill": "^6.23.0",
     "lodash": "^4.17.4",
-    "lodash-move": "^1.1.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/src/actions/creatures.js
+++ b/src/actions/creatures.js
@@ -17,3 +17,18 @@ export const creatureUpdate = creature => {
     creature
   }
 }
+
+export const creatureDelete = creature => {
+  return {
+    type: 'CREATURE_DELETE',
+    creature
+  }
+}
+
+export const reorderCreatures = (previousIndex, nextIndex) => {
+  return {
+    type: 'CREATURE_REORDER',
+    previousIndex,
+    nextIndex
+  }
+}

--- a/src/components/Creature.js
+++ b/src/components/Creature.js
@@ -13,6 +13,10 @@ export class Creature extends React.Component {
     this.props.onCounterSubmit({label, creatureId: this.props.creature.id})
   };
 
+  handleCreatureDelete = () => {
+    this.props.onCreatureDelete(this.props.creature)
+  }
+
   render() {
     const {creature} = this.props
     var counters = []
@@ -32,6 +36,7 @@ export class Creature extends React.Component {
         <h2 className="creature_name">{creature.name}</h2>
         {counters}
         <CreateButton onSubmit={this.handleCounterSubmit} buttonLabel="New Counter" />
+        <button onClick={this.handleCreatureDelete} >Delete Creature</button>
       </div>
     );
   }

--- a/src/components/CreatureList.js
+++ b/src/components/CreatureList.js
@@ -1,6 +1,6 @@
 // Libs
 import React from 'react';
-import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
+import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
@@ -30,23 +30,8 @@ const SortableList = SortableContainer(({items}) => {
 });
 
 class CreatureList extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      creatureIds: props.creatureIds
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      creatureIds: nextProps.creatureIds
-    })
-  }
-
   onAdvanceInitiative = () => {
-    const {creatureIds} = this.state;
-    creatureIds.push(creatureIds.shift());
-    this.setState({creatureIds})
+    this.props._creature.reorderCreatures(0, -1);
   }
 
   onCreatureSubmit = name => {
@@ -54,19 +39,21 @@ class CreatureList extends React.Component {
   }
 
   onSortEnd = ({oldIndex, newIndex}) => {
-    this.setState({
-      creatureIds: arrayMove(this.state.creatureIds, oldIndex, newIndex),
-    });
+    this.props._creature.reorderCreatures(oldIndex, newIndex);
   };
 
   handleCounterSubmit = counter => {
     this.props._counter.counterCreate(counter)
   };
 
+  handleCreatureDelete = (creature) => {
+    this.props._creature.creatureDelete(creature)
+  }
+
   render() {
     var creatures = []
-    if(_.size(this.state.creatureIds) > 0) {
-      _.forEach(this.state.creatureIds, (creatureId) => {
+    if(_.size(this.props.creatureIds) > 0) {
+      _.forEach(this.props.creatureIds, (creatureId) => {
         var creature   = this.props.creatures[creatureId];
         const counters = _.pick(this.props.counters, creature.counterIds);
         creatures.push(
@@ -75,6 +62,7 @@ class CreatureList extends React.Component {
             creature={creature}
             counters={counters}
             onCounterSubmit={this.handleCounterSubmit}
+            onCreatureDelete={this.handleCreatureDelete}
           />
         );
       });

--- a/src/reducers/counters.js
+++ b/src/reducers/counters.js
@@ -28,10 +28,7 @@ const allIds = (state = [], action) => {
     case 'COUNTER_CREATE':
       return state.concat(action.counter.id);
     case 'CREATURE_DELETE':
-      const nextState = _.without(state, action.creature.counterIds)
-      console.log(state)
-      console.log(action.creature.counterIds)
-      return nextState
+      return _.difference(state, action.creature.counterIds);
     default:
       return state;
   }

--- a/src/reducers/counters.js
+++ b/src/reducers/counters.js
@@ -1,4 +1,5 @@
 import {combineReducers} from 'redux';
+import _ from 'lodash';
 
 const byId = (state = {}, action) => {
   switch(action.type) {
@@ -15,6 +16,8 @@ const byId = (state = {}, action) => {
           ...action.counter
         }
       }
+    case 'CREATURE_DELETE':
+      return _.omit(state, action.creature.counterIds)
     default:
       return state;
   }
@@ -24,6 +27,11 @@ const allIds = (state = [], action) => {
   switch(action.type) {
     case 'COUNTER_CREATE':
       return state.concat(action.counter.id);
+    case 'CREATURE_DELETE':
+      const nextState = _.without(state, action.creature.counterIds)
+      console.log(state)
+      console.log(action.creature.counterIds)
+      return nextState
     default:
       return state;
   }

--- a/src/reducers/creatures.js
+++ b/src/reducers/creatures.js
@@ -1,4 +1,7 @@
 import {combineReducers} from 'redux';
+import _ from 'lodash';
+
+const arrayMove = require('array-move');
 
 const byId = (state = {}, action) => {
   switch(action.type) {
@@ -19,6 +22,8 @@ const byId = (state = {}, action) => {
         ...state,
         [action.creature.id]: action.creature
       };
+    case 'CREATURE_DELETE':
+      return _.omit(state, action.creature.id)
     default:
       return state;
   }
@@ -28,6 +33,12 @@ const allIds = (state = [], action) => {
   switch(action.type) {
     case 'CREATURE_CREATE':
       return state.concat(action.creature.id);
+    case 'CREATURE_DELETE':
+      return _.remove(state, (creatureId) => {
+          return creatureId !== action.creature.id
+        })
+    case 'CREATURE_REORDER':
+      return arrayMove(state, action.previousIndex, action.nextIndex)
     default:
       return state;
   }


### PR DESCRIPTION
This commit adds the functionality to delete a creature (this will also delete all counters that were associated with this creature), and it moves the function that is in charge of sorting the creatures on drags and on `advance initiative` to a reducer. The initiative order is the order of the creature ids in `creatures.allIds`.